### PR TITLE
Fix issue with the divider overlapping the left panel by half its size

### DIFF
--- a/src/SplitPanel.jsx
+++ b/src/SplitPanel.jsx
@@ -343,7 +343,7 @@ export default class SplitPanel extends React.Component {
     const offsets = [];
     const sizes = [];
     for (let i = 0; i < weights.length; i++) {
-      offsets.push(_.sum(sizes) + dividerCompensation * i);
+      offsets.push(_.sum(sizes) + 2 * dividerCompensation * i);
       const proportion = weights[i] / totalWeight;
       sizes.push(Math.max(
         proportion * this.refs.self[this.domSizeProperty] - dividerCompensation,


### PR DESCRIPTION
When I placed a div with a vertical scroll bar in the left panel of a split panel, I found that that divider overlapped the scroll bar by a few pixels. The divider position is set to the offset - dividerSize, but the code previously set the offset to the sum(sizes) + dividerCompensation (which is half the dividerSize for 2 panels). This fix adds 2 x dividerCompensation. I have only tested this with 2 panels. Please let me know if I have misunderstood the code or used it incorrectly. 
Thanks
Alex